### PR TITLE
docs: sync README with upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,147 +1,65 @@
-<div align="center">
-  <img src="assets/logo.svg" width="96" alt="EVE Flipper logo" />
+# EVE Flipper
 
-  <h1>EVE Flipper</h1>
+EVE Flipper is a local-first market analysis platform for EVE Online traders.
+It combines live ESI order books, historical market behavior, and execution-aware math to surface actionable opportunities across multiple trading workflows.
 
-  <p>
-    Local-first market intelligence, execution planning, and portfolio tooling for EVE Online traders.
-  </p>
+[![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white)](https://go.dev/)
+[![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)](https://react.dev/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![License](https://img.shields.io/badge/License-MIT-green)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/ilyaux/Eve-flipper)](https://github.com/ilyaux/Eve-flipper/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/ilyaux/Eve-flipper/total)](https://github.com/ilyaux/Eve-flipper/releases)
+[![Last Commit](https://img.shields.io/github/last-commit/ilyaux/Eve-flipper)](https://github.com/ilyaux/Eve-flipper/commits/master)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Server-5865F2?logo=discord&logoColor=white)](https://discord.gg/rnR2bw6XXX)
 
-  <p>
-    <a href="https://github.com/ilyaux/Eve-flipper/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/ilyaux/Eve-flipper?label=release"></a>
-    <a href="https://github.com/ilyaux/Eve-flipper/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/ilyaux/Eve-flipper/total"></a>
-    <a href="https://go.dev/"><img alt="Go" src="https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white"></a>
-    <a href="https://react.dev/"><img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black"></a>
-    <a href="https://www.typescriptlang.org/"><img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript&logoColor=white"></a>
-    <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/License-MIT-green"></a>
-    <a href="https://discord.gg/rnR2bw6XXX"><img alt="Discord" src="https://img.shields.io/badge/Discord-Join%20Server-5865F2?logo=discord&logoColor=white"></a>
-  </p>
-</div>
+## What It Includes
 
-## Overview
+### Trading Tabs
+- `Flipper (Radius)`: local buy/sell opportunities with execution-aware metrics.
+- `Regional Trade`: cross-region day-trade scanner with target marketplace controls and grouped output.
+- `Contract Arbitrage`: contract valuation and liquidation scenarios.
+- `Route`: multi-hop route builder with ISK/jump constraints.
+- `Station Trading`: same-station scanner with liquidity/risk filters.
+- `Industry`: production planning and industry ledger workflows.
+- `War Tracker`: demand/activity view for region-level opportunities.
+- `PLEX+`: PLEX analytics and profitability dashboards.
 
-EVE Flipper helps traders decide whether an opportunity is actually executable, not just mathematically attractive on top-of-book prices. It combines ESI market data, local history, orderbook depth, liquidity scoring, route risk, character data, and paper/live trade workflows in one local application.
+### Core UX and Analysis Features
+- `Execution-aware pricing`: expected fill price, slippage, fillability, and real profit fields.
+- `System blacklist`: ignore selected systems globally in scan parameters.
+- `Batch Builder`: build same-route cargo manifests from a selected deal.
+- `Auto-refresh`: cache-aware refresh for Flipper and Regional tabs.
+- `Player structures support`: optional structure inclusion (requires EVE login and access).
+- `Watchlist + Scan History`: persist and revisit tracked items and previous scans.
 
-The app is built for practical EVE trading:
-
-- Station trading and same-hub flipping.
-- Regional hauling and route opportunity scanning.
-- Contract arbitrage and liquidation checks.
-- Industry build-vs-buy analysis, reactions, invention, and project tracking.
-- Portfolio, wallet, PnL, cashflow, active orders, assets, and risk views.
-- Paper backtesting, orderbook snapshot recording, and trade journaling.
-
-Everything runs locally. There is no hosted service and no central database.
+### Local-First Runtime
+- Single backend binary with embedded frontend.
+- Default bind: `127.0.0.1:13370`.
+- SQLite persistence for config, history, and local state.
 
 ## Screenshots
 
-| Station Trading | Route Trading | Radius Scanner |
+| Station Trading | Route Trading | Flipper (Radius) |
 |---|---|---|
 | ![Station Trading](assets/screenshot-station.png) | ![Route Trading](assets/screenshot-routes.png) | ![Radius Scan](assets/screenshot-radius.png) |
 
-## Current Public Release
-
-The current public release is `v1.6.1`.
-
-Download it from:
-
-- [GitHub Releases](https://github.com/ilyaux/Eve-flipper/releases/latest)
-
-Release packages are published as two runtime families:
-
-| Runtime | Assets | Use When |
-|---|---|---|
-| Desktop app | `eve-flipper-desktop-windows-amd64.exe`, `eve-flipper-desktop-linux-*`, `eve-flipper-desktop-darwin-*` | You want the normal app window with the embedded backend. Recommended for most users. |
-| Web/server binary | `eve-flipper-web-windows-amd64.exe`, `eve-flipper-web-linux-*`, `eve-flipper-web-darwin-*` | You want to run the local backend and open the UI in a browser. |
-| Checksums | `SHA256SUMS.txt` | Used by the updater and for manual release verification. |
-
-## Main Modules
-
-| Module | What It Does |
-|---|---|
-| Flipper (Radius) | Finds local buy/sell opportunities around a source system using depth-aware profit, slippage, liquidity, and fillability math. |
-| Station Trading | Same-station market scanner for hub trading with advanced filters, active order context, history, and paper trade actions. |
-| Regional Trade | Cross-region scanner for hauling and market spread discovery. |
-| Route | Builds route opportunities with execution estimates, cargo trips, travel time, ISK/hour, liquidity, and gank-risk signals. |
-| Contract Arbitrage | Evaluates contracts, courier risk, collateral issues, liquidation assumptions, and suspicious pricing. |
-| Paper Backtest | Simulates hold and instant-flip strategies with configurable entry cadence, volume limits, price assumptions, ROI filters, fees, and equity charts. |
-| Trade Journal | Tracks manual and scanner-created paper/live trade records, live drafts from ESI, reconciliation, and suggested status updates. |
-| Portfolio and Risk | Calculates wallet, assets, active orders, exposure, PnL, optimizer diagnostics, and inventory-aware capital usage. |
-| Industry | Performs build-vs-buy analysis, material depth checks, sell-mode comparison, reactions, invention, project planning, blueprints, jobs, and ledger coverage. |
-| Wallet/Cashflow | Provides EveLedger-style foundations for income, outgoing, inventory mark-to-market, category views, and capital tracking. |
-| PLEX+ | Tracks PLEX-oriented market analytics and profitability dashboards. |
-| War/Demand Tracker | Surfaces region activity, demand hot zones, and opportunity context. |
-
-## Execution-Aware Trading
-
-The project intentionally avoids the most common market-tool trap: treating the first buy/sell order as if the whole position can trade there.
-
-Current execution logic includes:
-
-- VWAP-style depth walking for market scanner and route calculations.
-- Slippage and safe quantity calculation.
-- Real profit fields after depth and fees.
-- Liquidity, fill-rate, fill-time, turnover, and confidence signals.
-- Daily volume and history-aware filters.
-- Active character orders/assets context where available.
-- Route cargo trips, execution minutes, safety delay, and ISK/hour.
-- Gank-risk and hot-zone indicators for hauling.
-- Courier and collateral risk signals.
-
-## Backtesting and Orderbook Replay
-
-The Paper Backtest module supports two practical modes:
-
-- Hold mode: buy, hold for a configured period, then exit using historical assumptions.
-- Instant flip mode: simulate repeated buy-haul-sell cycles when opportunities appear again after cooldown.
-
-The app can also record orderbook snapshots locally and replay recorded coverage. ESI does not provide historical orderbook depth retroactively, so real historical orderbook replay becomes useful only after you have accumulated your own snapshots.
-
-## Character-Aware Workflows
-
-EVE SSO is optional, but login unlocks deeper workflows:
-
-- Character wallet, transactions, journal, orders, assets, location, skills, and blueprints.
-- Structure market access where your character has access.
-- Live trade journal drafts and reconciliation.
-- Portfolio optimizer using wallet, inventory, and active orders.
-- Industry coverage against owned materials and BPO/BPCs.
-- Active industry job sync.
-- EVE UI actions such as open market and set waypoint.
-
 ## Quick Start
 
-### Desktop Release
+### Option 1: Release binaries
 
-1. Download the desktop asset for your OS from [latest release](https://github.com/ilyaux/Eve-flipper/releases/latest).
-2. Run the binary.
-3. Add a character if you want SSO-backed features, or use public-market scanners without login.
+Download the latest build:
+- https://github.com/ilyaux/Eve-flipper/releases
 
-### Web/Server Release
+Release asset naming:
+- Classic binary: `eve-flipper-windows-amd64.exe` (and `linux/darwin` variants)
+- Wails desktop binaries: `eve-flipper-wails-windows-amd64.exe`, `eve-flipper-wails-linux-amd64`, `eve-flipper-wails-linux-arm64`, `eve-flipper-wails-darwin-amd64`, `eve-flipper-wails-darwin-arm64`
 
-Windows:
+Run the binary and open:
+- `http://127.0.0.1:13370`
 
-```powershell
-.\eve-flipper-web-windows-amd64.exe
-```
-
-Linux/macOS:
-
-```bash
-chmod +x ./eve-flipper-web-linux-amd64
-./eve-flipper-web-linux-amd64
-```
-
-Then open:
-
-```text
-http://127.0.0.1:13370
-```
-
-### Build From Source
+### Option 2: Build from source
 
 Prerequisites:
-
 - Go `1.25+`
 - Node.js `20+`
 - npm
@@ -149,12 +67,89 @@ Prerequisites:
 ```bash
 git clone https://github.com/ilyaux/Eve-flipper.git
 cd Eve-flipper
-npm -C frontend ci
+npm -C frontend install
 npm -C frontend run build
-go run .
+go build -o build/eve-flipper .
+./build/eve-flipper
 ```
 
-## Developer Commands
+Windows PowerShell helpers:
+
+```powershell
+.\make.ps1 build
+.\make.ps1 run
+```
+
+Unix Make targets:
+
+```bash
+make build
+make run
+```
+
+### Option 3: Wails desktop variant (separate mode)
+
+This mode keeps the existing runtime modes untouched (`Go embedded web app` and `Tauri`),
+and adds an additional desktop build powered by Wails.
+
+PowerShell:
+
+```powershell
+.\make.ps1 wails
+```
+
+Output:
+- `build/eve-flipper-wails.exe`
+
+Manual build equivalent:
+
+```bash
+go build -tags wails,production -ldflags "-s -w -H=windowsgui -X main.version=dev" -o build/eve-flipper-wails.exe .
+```
+
+Run directly:
+
+```powershell
+.\make.ps1 wails-run
+```
+
+Unix Make:
+
+```bash
+make wails
+make wails-run
+```
+
+## Runtime Flags
+
+```bash
+./eve-flipper --host 127.0.0.1 --port 13370
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host` | `127.0.0.1` | Bind address (`0.0.0.0` for LAN/remote access) |
+| `--port` | `13370` | HTTP port |
+
+## EVE SSO (Optional)
+
+Many scanners work without login, but these features require EVE SSO:
+- Character-aware fees/skills autofill
+- Character orders/assets-based workflows
+- Player structure market data and structure names
+- Corporation dashboards/endpoints
+
+Create `.env` in repo root for local/source builds:
+
+```env
+ESI_CLIENT_ID=your-client-id
+ESI_CLIENT_SECRET=your-client-secret
+ESI_CALLBACK_URL=http://localhost:13370/api/auth/callback
+```
+
+Do not commit `.env`.
+
+## Development Workflow
 
 Backend:
 
@@ -165,117 +160,48 @@ go run .
 Frontend dev server:
 
 ```bash
-npm -C frontend ci
+npm -C frontend install
 npm -C frontend run dev
 ```
 
-Production web build:
-
-```bash
-npm -C frontend run build
-go build -o build/eve-flipper .
-```
-
-Wails desktop build:
-
-```bash
-npm -C frontend run build:wails
-go build -tags "wails,production" -ldflags "-s -w -X main.version=dev" -o build/eve-flipper-desktop .
-```
-
-PowerShell helpers:
-
-```powershell
-.\make.ps1 build
-.\make.ps1 run
-.\make.ps1 test
-.\make.ps1 wails
-.\make.ps1 wails-run
-```
-
-Unix Make targets:
-
-```bash
-make build
-make run
-make test
-make wails
-```
-
-## Runtime Configuration
-
-The web/server binary listens on localhost by default:
-
-```bash
-./eve-flipper-web-linux-amd64 --host 127.0.0.1 --port 13370
-```
-
-| Flag | Default | Description |
-|---|---:|---|
-| `--host` | `127.0.0.1` | Bind address. Use `0.0.0.0` only if you know how to secure the host. |
-| `--port` | `13370` | HTTP port for the local web UI and API. |
-
-Desktop builds start their own local backend internally. If `13370` is already busy, the desktop app can use a free local port and route API calls through the Wails asset server.
-
-## EVE SSO Setup for Source Builds
-
-Official release builds are configured through GitHub release secrets. For local source builds, create `.env` in the repository root:
-
-```env
-ESI_CLIENT_ID=your-client-id
-ESI_CLIENT_SECRET=your-client-secret
-ESI_CALLBACK_URL=http://localhost:13370/api/auth/callback
-```
-
-Do not commit `.env`.
-
-Useful scopes include market orders, wallet, assets, skills, blueprints, industry jobs, structures, corporation data, and EVE UI actions. The app requests the scopes required by its character-aware modules.
-
-## Data and Privacy
-
-- SQLite stores local config, history, snapshots, journal records, projects, and cached state.
-- ESI tokens are stored locally.
-- Public market scans can run without EVE login.
-- No project-operated cloud backend receives your trading data.
-
-## Release Safety
-
-- Release binaries are built by GitHub Actions from tags.
-- Release assets include `SHA256SUMS.txt`.
-- The auto-updater verifies the downloaded asset checksum before replacing the local binary.
-- Windows release builds include version metadata and app icon resources.
-
-## Known Limits
-
-- ESI does not provide old orderbook depth. Historical orderbook replay requires locally recorded snapshots.
-- Market data can move between scan and execution. Always check volume, fees, taxes, standings, skills, and order depth before committing serious ISK.
-- Gank-risk and route scoring are decision support, not safety guarantees.
-- Industry and portfolio tools are models. They improve discipline, but they do not replace manual review of jobs, orders, assets, and market conditions.
-
-## Tests
+Tests:
 
 ```bash
 go test ./...
-go test -tags wails ./...
-npm -C frontend run build
-npm -C frontend run build:wails
 ```
 
-## Documentation and Community
+Production frontend build check:
 
-- [Project wiki](https://github.com/ilyaux/Eve-flipper/wiki)
-- [Getting Started](https://github.com/ilyaux/Eve-flipper/wiki/Getting-Started)
-- [API Reference](https://github.com/ilyaux/Eve-flipper/wiki/API-Reference)
-- [Discord](https://discord.gg/rnR2bw6XXX)
+```bash
+npm -C frontend run build
+```
+
+## Documentation
+
+- Project wiki: https://github.com/ilyaux/Eve-flipper/wiki
+- Getting Started: https://github.com/ilyaux/Eve-flipper/wiki/Getting-Started
+- API Reference: https://github.com/ilyaux/Eve-flipper/wiki/API-Reference
+- Station Trading: https://github.com/ilyaux/Eve-flipper/wiki/Station-Trading
+- Contract Scanner: https://github.com/ilyaux/Eve-flipper/wiki/Contract-Scanner
+- Execution Plan: https://github.com/ilyaux/Eve-flipper/wiki/Execution-Plan
+- PLEX Dashboard: https://github.com/ilyaux/Eve-flipper/wiki/PLEX-Dashboard
+
+## Security Notes
+
+- By default, server listens only on localhost.
+- ESI credentials are optional for non-SSO features.
+- If exposed beyond localhost (`--host 0.0.0.0`), use your own network hardening (firewall/reverse proxy/TLS).
 
 ## Contributing
 
-Issues, pull requests, bug reports, screenshots, and trading workflow feedback are welcome. For larger changes, describe the trading scenario and the expected behavior clearly so it can be tested against real EVE market conditions.
+See:
+- `CONTRIBUTING.md`
 
 ## License
 
-MIT License. See [LICENSE](LICENSE).
+MIT License. See `LICENSE`.
 
 ## Disclaimer
 
-EVE Flipper is an independent third-party project and is not affiliated with CCP Games. EVE Online and related trademarks are property of CCP hf.
+EVE Flipper is an independent third-party project and is not affiliated with CCP Games.
+EVE Online and related trademarks are property of CCP hf.


### PR DESCRIPTION
Brings the README in line with the current upstream version.